### PR TITLE
Upgrade v0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/Form/Guess/SetTypeGuesser.php
+++ b/Form/Guess/SetTypeGuesser.php
@@ -70,7 +70,7 @@ class SetTypeGuesser extends DoctrineOrmTypeGuesser
         $fullClassName = $this->registeredTypes[$fieldType];
 
         if (!is_subclass_of($fullClassName, $this->parentSetTypeClass)) {
-            throw new InvalidClassSpecifiedException(sprintf('The class "%s" is wrong. You must specify class which inherit "Okapon\DoctrineSetTypeBundle\DBAL\Types\AbstractSetType".', $fullClassName));
+            throw new InvalidClassSpecifiedException(sprintf('The class "%s" is wrong. You must specify class which inherit "%s".', $fullClassName, AbstractSetType::class));
         }
 
         // render checkboxes

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `DoctrineSetTypeBundle` provides support MySQL SET type for Doctrine2 in you
 
 ## Requirements
 
-* PHP 5.4+
+* PHP 5.5+
 * Symfony 2.5+
 * Doctrine 2.2+
 
@@ -33,7 +33,7 @@ The `DoctrineSetTypeBundle` provides support MySQL SET type for Doctrine2 in you
 Using composer
 
 ```
-$ composer require okapon/doctrine-set-type-bundle "0.1.2"
+$ composer require okapon/doctrine-set-type-bundle "0.2.0"
 ```
 
 ## Step 2: Enable the Bundle
@@ -100,7 +100,7 @@ class UserGroupType extends AbstractSetType
     /**
      * {@inheritdoc}
      */
-     protected $name = 'UserGroupType'; // This is Optional. Automatically registered shord class name. 
+     protected $name = 'UserGroupType'; // This is Optional. Automatically registered shord class name.
 
     /**
      * define your SET type.
@@ -162,9 +162,9 @@ class User
     private $username;
 
     /**
-     * @var array 
+     * @var array
      *
-     * @DoctrineAssert\SetType(target="AppBundle\DBAL\Types\UserGroupType")
+     * @DoctrineAssert\SetType(class="AppBundle\DBAL\Types\UserGroupType")
      * @ORM\Column(name="groups", type="UserGroupType", nullable=true) // mapping_type
      */
     private $groups;
@@ -206,7 +206,7 @@ And also You can validate your type by adding the following annotation.
 
 ```
     /**
-     * @DoctrineAssert\SetType(target="AppBundle\DBAL\Types\UserGroupType")
+     * @DoctrineAssert\SetType(class="AppBundle\DBAL\Types\UserGroupType")
      */
     private $groups;
 ```

--- a/Tests/Validator/SetTypeValidatorTest.php
+++ b/Tests/Validator/SetTypeValidatorTest.php
@@ -53,7 +53,7 @@ class SetTypeValidatorTest extends \PHPUnit_Framework_TestCase
     public function testTargetSpecifiedByClassNameExpected()
     {
         $constraint = new SetType([
-            'target' => null,
+            'class' => null,
         ]);
 
         $this->setTypeValidator->validate([UserGroupType::GROUP1], $constraint);
@@ -67,7 +67,7 @@ class SetTypeValidatorTest extends \PHPUnit_Framework_TestCase
     public function testTargetIsSpecifiedByExistingClassNameExpected()
     {
         $constraint = new SetType([
-            'target' => 'NotExistClassName',
+            'class' => 'NotExistClassName',
         ]);
 
         $this->setTypeValidator->validate([UserGroupType::GROUP1], $constraint);
@@ -83,7 +83,7 @@ class SetTypeValidatorTest extends \PHPUnit_Framework_TestCase
     public function testValidParam($param)
     {
         $constraint = new SetType([
-            'target' => 'Okapon\DoctrineSetTypeBundle\Tests\Fixtures\DBAL\Types\UserGroupType'
+            'class' => 'Okapon\DoctrineSetTypeBundle\Tests\Fixtures\DBAL\Types\UserGroupType'
         ]);
 
         $this->setTypeValidator->initialize($this->context);
@@ -117,7 +117,7 @@ class SetTypeValidatorTest extends \PHPUnit_Framework_TestCase
     public function testInvalidTypeParam()
     {
         $constraint = new SetType([
-            'target' => 'Okapon\DoctrineSetTypeBundle\Tests\Fixtures\DBAL\Types\UserGroupType'
+            'class' => 'Okapon\DoctrineSetTypeBundle\Tests\Fixtures\DBAL\Types\UserGroupType'
         ]);
 
         $this->setTypeValidator->initialize($this->context);
@@ -135,7 +135,7 @@ class SetTypeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context = Phake::mock('Symfony\Component\Validator\Context\ExecutionContext');
 
         $constraint = new SetType([
-            'target' => 'Okapon\DoctrineSetTypeBundle\Tests\Fixtures\DBAL\Types\UserGroupType'
+            'class' => 'Okapon\DoctrineSetTypeBundle\Tests\Fixtures\DBAL\Types\UserGroupType'
         ]);
 
         $message = 'One or more of the given values is invalid.';

--- a/Validator/Constraints/SetType.php
+++ b/Validator/Constraints/SetType.php
@@ -14,15 +14,15 @@ use Symfony\Component\Validator\Constraints\Choice;
 class SetType extends Choice
 {
     /**
-     * @var string $target validation target class name
+     * @var string $class validation target class name
      */
-    public $target;
+    public $class;
 
     /**
      * {@inheritdoc}
      */
     public function getRequiredOptions()
     {
-        return ['target'];
+        return ['class'];
     }
 }

--- a/Validator/Constraints/SetTypeValidator.php
+++ b/Validator/Constraints/SetTypeValidator.php
@@ -28,17 +28,17 @@ class SetTypeValidator extends ChoiceValidator
     public function validate($value, Constraint $constraint)
     {
         /** @var SetType $constraint */
-        if (!$constraint->target) {
+        if (!$constraint->class) {
             throw new ConstraintDefinitionException('Target is not specified');
         }
 
-        /** @var string $target class name of inheriting \Okapon\DoctrineSetTypeBundle\DBAL\Types\AbstractSetType */
-        $target = $constraint->target;
-        if (!class_exists($target)) {
+        /** @var string $class class name of inheriting \Okapon\DoctrineSetTypeBundle\DBAL\Types\AbstractSetType */
+        $class = $constraint->class;
+        if (!class_exists($class)) {
             throw new TargetClassNotExistException('Target class not exist.');
         }
 
-        $constraint->choices = $target::getValues();
+        $constraint->choices = $class::getValues();
         $constraint->multiple =true;
 
         parent::validate($value, $constraint);


### PR DESCRIPTION
## Change overview

[BC Break] SetType assert annotation changed

`@DoctrineAssert\SetType` is changed

before

```
    /**
     * @var array 
     *
     * @DoctrineAssert\SetType(target="AppBundle\DBAL\Types\UserGroupType")
     * @ORM\Column(name="groups", type="UserGroupType", nullable=true) // mapping_type
     */
    private $groups;
```

after

```
    /**
     * @var array 
     *
     * @DoctrineAssert\SetType(class="AppBundle\DBAL\Types\UserGroupType")
     * @ORM\Column(name="groups", type="UserGroupType", nullable=true) // mapping_type
     */
    private $groups;
```
### Requirements
- PHP5.5+
