### PR TITLE
Allow to store and load SET from SQLite DB

### DIFF
--- a/DBAL/Types/AbstractSetType.php
+++ b/DBAL/Types/AbstractSetType.php
@@ -3,7 +3,7 @@
 namespace Okapon\DoctrineSetTypeBundle\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -79,8 +79,8 @@ abstract class AbstractSetType extends Type
             )
         );
 
-        if ($platform instanceof SqlitePlatform) {
-            return 'TEXT';
+        if (!$platform instanceof MySqlPlatform) {
+            return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
         }
 
         return sprintf('SET(%s)', $values);

--- a/DBAL/Types/AbstractSetType.php
+++ b/DBAL/Types/AbstractSetType.php
@@ -3,6 +3,7 @@
 namespace Okapon\DoctrineSetTypeBundle\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -77,6 +78,10 @@ abstract class AbstractSetType extends Type
                 $this->getValues()
             )
         );
+
+        if ($platform instanceof SqlitePlatform) {
+            return 'TEXT';
+        }
 
         return sprintf('SET(%s)', $values);
     }


### PR DESCRIPTION
This is useful when you use SQLLite for UnitTests. It also makes your Bundle useful with SQLLite because then the checks are done at least in PHP (also when the DB didn't know SETs).
