### PR TITLE
Form Type Guesser should return null if it is not a SET ENUM

### DIFF
--- a/Form/Guess/SetTypeGuesser.php
+++ b/Form/Guess/SetTypeGuesser.php
@@ -70,7 +70,7 @@ class SetTypeGuesser extends DoctrineOrmTypeGuesser
         $fullClassName = $this->registeredTypes[$fieldType];
 
         if (!is_subclass_of($fullClassName, $this->parentSetTypeClass)) {
-            throw new InvalidClassSpecifiedException(sprintf('The class "%s" is wrong. You must specify class which inherit "%s".', $fullClassName, AbstractSetType::class));
+            return;
         }
 
         // render checkboxes


### PR DESCRIPTION
Your SET Doctrine Type is not the only one. So throwing an Exception here removes the possibility to have also other Doctrine Types in the Application. If the guesser can not handle the type, it should return NULL.
