### PR TITLE
Change .travis.yml to support several versions testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,30 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
 
-before_script:
-  - composer install --dev
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 5.6
+      env: SYMFONY_VERSION=2.6.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
+  allow_failures:
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
+
+before_install:
+  - composer selfupdate
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+
+install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
   - phpunit --coverage-clover=coverage.clover

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+### 0.4.0 (2015-10-14)
+
+Change support versions.
+The requirements PHP5.5+, Symfony2.6+,
+
+* Add several versions(PHP, hhvm and Symfony) tesing.
 
 ### 0.3.1 (2015-10-14)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `DoctrineSetTypeBundle` provides support MySQL SET type for Doctrine2 in you
 ## Requirements
 
 * PHP 5.5+
-* Symfony 2.5+
+* Symfony 2.6+
 * Doctrine 2.3+
 
 ## Supported platforms

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "symfony/symfony": "~2.3",
+        "php": ">=5.5.0",
+        "symfony/symfony": "~2.6",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
- Start supporting several versions testing, because travis only test latest stable version of symfony.
- Decide to discontinue support symfony2.5 and 2.3 test.
