### PR TITLE
remove dependency to symfony/symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/http-kernel": "~2.6|~3.0",
         "symfony/form": "~2.6|~3.0",
         "symfony/validator": "~2.6|~3.0",
+        "symfony/yaml": "~2.6|~3.0",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/http-kernel": "~2.6|~3.0",
         "symfony/form": "~2.6|~3.0",
         "symfony/validator": "~2.6|~3.0",
+        "symfony/yaml": "~2.6|~3.0",
         "symfony/doctrine-bridge": "~2.6|~3.0",
         "doctrine/orm": "~2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,11 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "symfony/symfony": "~2.6|~3.0",
+        "symfony/dependency-injection": "~2.6|~3.0",
+        "symfony/config": "~2.6|~3.0",
+        "symfony/http-kernel": "~2.6|~3.0",
+        "symfony/form": "~2.6|~3.0",
+        "symfony/validator": "~2.6|~3.0",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "symfony/http-kernel": "~2.6|~3.0",
         "symfony/form": "~2.6|~3.0",
         "symfony/validator": "~2.6|~3.0",
+        "symfony/doctrine-bridge": "~2.6|~3.0",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/orm": "~2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.5.0",
+        "phpunit/phpunit": ">=4.5.0,<=6",
         "phake/phake": ">=2.0.0@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/orm": "~2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.5.0,<=6",
+        "phpunit/phpunit": ">=4.5.0,<6",
         "phake/phake": ">=2.0.0@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "symfony/http-kernel": "~2.6|~3.0",
         "symfony/form": "~2.6|~3.0",
         "symfony/validator": "~2.6|~3.0",
-        "symfony/yaml": "~2.6|~3.0",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=4.5.0",
         "phake/phake": ">=2.0.0@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/validator": "~2.6|~3.0",
         "symfony/yaml": "~2.6|~3.0",
         "symfony/doctrine-bridge": "~2.6|~3.0",
+        "symfony/translation": "~2.6|~3.0",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Libraries should not depend on metapackage symfony/symfony, but on the Symfony components they use.
See https://symfony.com/doc/current/setup/flex.html#upgrading-existing-applications-to-flex